### PR TITLE
Removing double quotes from token description

### DIFF
--- a/api/daemon.js
+++ b/api/daemon.js
@@ -526,7 +526,7 @@ function createToken(name, supply, description) {
         console.log('Creating token ' + name + ', supply: ' + supply + ' (' + (supply * 0.00000001) + ') ' + ' description: ' + description)
 
         let args = to_cli_args('tokencreate ' + name + ' ' + supply * 0.00000001)
-        if(description !== '') args.push('"' + description + '"')
+        if(description !== '') args.push('' + description + '')
 
         child_process.execFile(cli_path, args, (error, stdout, stderr) => {
 


### PR DESCRIPTION
Solving bug #4 